### PR TITLE
Added options to skip SPAdes and/or EMIRGE; updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Python installed. (OSX is for the brave, we have not tested this!)
 
  These tools need to be "in your $PATH" so that *phyloFlash* can find
  them. To see whether all required tools are available, just run
- *phyloFlash* without arguments:
+ *phyloFlash* with the option ```check_env```:
 
  ```bash
  cd phyloFlash-2.0
- ./phyloFlash.pl
+ ./phyloFlash.pl -check_env
  ```
 
 Preparing the Reference Database
@@ -82,6 +82,9 @@ Synopsis
 
 Use the ```-help``` option to display a brief help and the ```-man``` 
 option to display a man-file. 
+
+Use the ```-skip_spades``` and/or ```-skip_emirge``` options to turn off
+SSU sequence reconstruction with SPAdes assembler or EMIRGE respectively.
 
 Expected Performance
 --------------------

--- a/phyloFlash_plotscript.R
+++ b/phyloFlash_plotscript.R
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-## plotscript.r by Brandon
+## plotscript.r by Brandon Seah (kbseah@mpi-bremen.de)
 
 ## Prerequisites: APE package in R
 ## Usage: Rscript plotscript.r --args <treefile> <histofile>
@@ -10,18 +10,19 @@ args <- commandArgs(trailingOnly=TRUE)
 treefile <- args[2]
 histofile <- args[3]
 
-## Plot tree from Newick .tree file (guide tree produced by MAFFT) and output PDF plot
-library(ape)							# ape package for phylogenetics
-thetree <- read.tree(file=treefile)
-
-pdf(file=paste(treefile,"pdf",sep="."),width=11,height=8)
-plot(thetree,type="phylogram",no.margin=TRUE,font=1,cex=0.5)
-dev.off()
-
-png(file=paste(treefile,"png",sep="."),width=1100,height=800)
-plot(thetree,type="phylogram",no.margin=TRUE,font=1,cex=0.5)
-dev.off()
-
+if (treefile != "NULL") {   # If no Newick tree file was generated (when -skip_emirge and -skip_spades options activated), skip this step
+    ## Plot tree from Newick .tree file (guide tree produced by MAFFT) and output PDF plot
+    library(ape)							# ape package for phylogenetics
+    thetree <- read.tree(file=treefile)
+    
+    pdf(file=paste(treefile,"pdf",sep="."),width=11,height=8)
+    plot(thetree,type="phylogram",no.margin=TRUE,font=1,cex=0.5)
+    dev.off()
+    
+    png(file=paste(treefile,"png",sep="."),width=1100,height=800)
+    plot(thetree,type="phylogram",no.margin=TRUE,font=1,cex=0.5)
+    dev.off()
+}
 
 ## Plot insert size histogram
 histo <- read.table(file=histofile,header=F,sep="\t",skip=1)


### PR DESCRIPTION
New options ```-skip_emirge``` and ```-skip_spades```
Added if/else statements to report generation (plain text, html, and csv)
New subroutine ```process_required_tools()``` to generate list of tools
```check_environment()``` now comes after ```parse_cmdline()```; therefore -check_env option added 
Fixed version numbering in HTML output
Fixed typo in HTML output