### PR TITLE
Dev - bug fixes

### DIFF
--- a/PhyloFlash.pm
+++ b/PhyloFlash.pm
@@ -1262,9 +1262,9 @@ sub initialize_outfiles_hash {
       "spades_log",
       {
         description => "Log file from SPAdes assembler",
-        discard     => 1,
+        discard     => 0,
         filename    => "$libraryNAME.spades.out",
-        intable     => 0,
+        intable     => 1,
       },
       "full_len_class",
       {
@@ -1332,9 +1332,9 @@ sub initialize_outfiles_hash {
       "emirge_log",
       {
         description => "Log file from EMIRGE sequence reconstruction",
-        discard     => 1,
+        discard     => 0,
         filename    => "$libraryNAME.emirge.out",
-        intable     => 0,
+        intable     => 1,
       },
       "assemratio_csv",
       {
@@ -1474,7 +1474,7 @@ sub initialize_outfiles_hash {
         description => "phyloFlash log file",
         discard     => 0,
         filename    => "$libraryNAME.phyloFlash.log",
-        intable     => 0,
+        intable     => 1,
       },
       "phyloFlash_archive",
       {

--- a/PhyloFlash.pm
+++ b/PhyloFlash.pm
@@ -586,6 +586,8 @@ sub fasta_copy_except {
         open_or_die(\$dfh, ">", $dest);
         my %acc_hash = map { $_ => 1 } @accs;
         my $skip = 0;
+        my $num_acc = scalar (keys %acc_hash);
+        msg ("Number of sequences to skip: $num_acc");
         while(my $row = <$sfh>) {
             if (substr($row, 0, 1) eq '>') {
                 my ($acc) = ($row =~ m/>([^ ]*) /);

--- a/PhyloFlash.pm
+++ b/PhyloFlash.pm
@@ -916,8 +916,10 @@ sub fix_rname_taxstr {
     foreach my $id (keys %$sam_href) {
         foreach my $segment (keys %{$sam_href->{$id}}) {
             foreach my $rname (keys %{$sam_href->{$id}{$segment}}) {
-                my $new_rname = join " ", ($sam_href->{$id}{$segment}{$rname}{'RNAME'}, $acc_href->{$sam_href->{$id}{$segment}{$rname}{'RNAME'}});
-                $sam_href->{$id}{$segment}{$rname}{'RNAME'} = $new_rname;
+                foreach my $href (@{$sam_href->{$id}{$segment}{$rname}}) {
+                    my $new_rname = join " ", ($href->{'RNAME'}, $acc_href->{$href->{'RNAME'}});
+                    $href->{'RNAME'} = $new_rname;
+                }
             }
         }
     }
@@ -933,9 +935,17 @@ sub samaref_to_lines {
         $fastq_href) = @_;
     my @lines;
     foreach my $href (@$aref) {
+        # Split read ID 
+        my $id_fwd = $href->{'QNAME'};
+        #my $id_rev = $href->{'QNAME'};
+        my $sep;
+        if ($id_fwd =~ m/^(.+)([:\/_])[12]$/) {
+            $id_fwd = $1.$2.'1';
+            #$id_rev = $1.$2.'2';
+        }
         # Splice in first segment dummy entry if this is rev with fwd read unmapped
         if ($href->{'FLAG'} & 0x80 && $href->{'FLAG'} & 0x8) {
-            my @splice = ($href->{'QNAME'}, # QNAME
+            my @splice = ($id_fwd, # QNAME
                           0x1 + 0x4 + 0x40, # Paired read, segment unmapped, first segment
                           '*', # RNAME
                           '0', # POS
@@ -981,9 +991,11 @@ sub fix_pairing_flags {
             # Flag 0x2 - both segments have alignments
             foreach my $segment (keys %{$sam_href->{$id}}) {
                 foreach my $ref (keys %{$sam_href->{$id}{$segment}}) {
-                    $sam_href->{$id}{$segment}{$ref}{'FLAG'} += 0x2 unless $sam_href->{$id}{$segment}{$ref}{'FLAG'} & 0x2;
-                    # Record if flag 0x10 set for this segment
-                    $segment_revcomp{$segment} ++ if $sam_href->{$id}{$segment}{$ref}{'FLAG'} & 0x10;
+                    foreach my $href (@{$sam_href->{$id}{$segment}{$ref}}) {
+                        $href->{'FLAG'} += 0x2 unless $href->{'FLAG'} & 0x2;
+                        # Record if flag 0x10 set for this segment
+                        $segment_revcomp{$segment} ++ if $href->{$ref}{'FLAG'} & 0x10;
+                    }
                 }
             }
             # Sweep through once more
@@ -991,7 +1003,9 @@ sub fix_pairing_flags {
             foreach my $segment (keys %{$sam_href->{$id}}) {
                 foreach my $ref (keys %{$sam_href->{$id}{$segment}}) {
                     if (defined $segment_revcomp{$other_segment{$segment}}) {
-                        $sam_href->{$id}{$segment}{$ref}{'FLAG'} += 0x20 unless $sam_href->{$id}{$segment}{$ref}{'FLAG'} & 0x20;
+                        foreach my $href (@{$sam_href->{$id}{$segment}{$ref}}) {
+                            $href->{'FLAG'} += 0x20 unless $href->{'FLAG'} & 0x20;
+                        }
                     }
                 }
             }
@@ -1000,13 +1014,14 @@ sub fix_pairing_flags {
             # Flag 0x8 - next segment unmapped
             foreach my $segment (keys %{$sam_href->{$id}}) {
                 foreach my $ref (keys %{$sam_href->{$id}{$segment}}) {
-                    $sam_href->{$id}{$segment}{$ref}{'FLAG'} -= 0x2 if $sam_href->{$id}{$segment}{$ref}{'FLAG'} & 0x2;
-                    $sam_href->{$id}{$segment}{$ref}{'FLAG'} += 0x8 unless $sam_href->{$id}{$segment}{$ref}{'FLAG'} & 0x8;
+                    foreach my $href (@{$sam_href->{$id}{$segment}{$ref}}) {
+                        $href->{'FLAG'} -= 0x2 if $href->{'FLAG'} & 0x2;
+                        $href->{'FLAG'} += 0x8 unless $href->{'FLAG'} & 0x8;
+                    }
                 }
             }
         }
     }
-
     # No return value because it modifies hash in place
 }
 
@@ -1038,11 +1053,17 @@ sub read_sortmerna_sam {
 
         # Hash SAM record by line number
         push @samhref_arr, $href;
-        #$samhash_by_line {$counter} = $href;
 
-        # Split read ID on first whitespace [not necessary as sortmerna already does this]
-        #my ($id, @discard) = split / /, $href->{'QNAME'};
+        # Sortmerna splits readname on first whitespace
         my $id = $href->{'QNAME'};
+        # If readname has a hard suffix indicated fwd or reverse segment, rename
+        # to match forward read and hash by this key.
+        # This is because BBmap will later rename QNAME to match forward read
+        # and this is the key that is needed to search for reads that map to
+        # assembly
+        if ($id =~ m/^(.+)([:\/_])[12]$/) {
+            $id = $1.$2.'1';
+        }
 
         # Get sequence revcomp if bitflag 0x10 is set
         my $sequence_original;
@@ -1078,11 +1099,11 @@ sub read_sortmerna_sam {
 
         # Check whether it is primary or secondary alignment for this read
         # Assume that supplementary alignments not reported
-        if (defined $samhash_by_qname_segment_ref{$href->{'QNAME'}}{$segment}) {
+        if (defined $samhash_by_qname_segment_ref{$id}{$segment}) {
             # Flag 0x100 as secondary alignment if entry for this read already encountered
             $href->{'FLAG'} += 0x100 unless $href->{'FLAG'} & 0x100;
         }
-        $samhash_by_qname_segment_ref{$href->{'QNAME'}}{$segment}{$href->{'RNAME'}} = $href;
+        push @{$samhash_by_qname_segment_ref{$id}{$segment}{$href->{'RNAME'}}}, $href;
         $counter ++;
     }
     close($fh);
@@ -1129,38 +1150,44 @@ sub read_interleaved_fastq {
         chomp $line;
         my $modulo = $counter % 8;
         last if defined $limit && ( $counter / 8 ) > $limit;
-        if ($counter % 8 == 0 && $line =~ m/^@(.+)/) {
+        if ($modulo == 0 && $line =~ m/^@(.+)/) {
             # Header line of fwd read
             my $fullheader = $1;
             my ($id, @discard) = split / /, $fullheader; # Split on whitespace
+            # Strip any suffix indicating fwd or rev segment
+            if ($id =~ m/^(.+)([:\/_])[12]/) {
+                $id = $1.$2.'1';
+            }
             $currid = $id;
             if (defined $hash{$currid}) {
                 # If another sequence of this name already defined, warn
                 print STDERR "WARNING: Splitting Fastq header on whitespace yields non-unique seq ID: $currid\n";
             }
             $hash{$currid}{'fwd'}{'fullheader'} = $fullheader;
-        } elsif ($counter % 8 == 1) {
+        } elsif ($modulo == 1) {
             # Seq line of fwd read
             $hash{$currid}{'fwd'}{'seq'} = $line;
             $hash{$currid}{'byseq'}{$line} = 'fwd';
-        } elsif ($counter % 8 == 3) {
+        } elsif ($modulo == 3) {
             # Quality line of fwd read
             $hash{$currid}{'fwd'}{'qual'} = $line;
-        } elsif ($counter % 8 == 4 && $line =~ m/^@(.+)/) {
+        } elsif ($modulo == 4 && $line =~ m/^@(.+)/) {
             # Header line of rev read
             my $fullheader = $1;
             my ($id, @discard) = split / /, $fullheader; # Split on whitespace
-            if ($id ne $currid) {
-                print STDERR "WARNING: Fastq rev read header $id does not match fwd read $currid at line $counter\n";
-                print STDERR "Check if interleaved file correctly formatted\n";
+            # Strip any suffix indicating fwd or rev segment
+            if ($id =~ m/^(.+)([:\/_])[12]/) {
+                $id = $1.$2.'1';
             }
-
+            if ($id ne $currid) {
+                msg ("WARNING: Fastq rev read header $id does not match fwd read $currid at line $counter\nCould not recognize standard read segment suffix\nCheck if interleaved file correctly formatted");
+            }
             $hash{$currid}{'rev'}{'fullheader'} = $fullheader;
-        } elsif ($counter % 8 == 5) {
+        } elsif ($modulo == 5) {
             # Seq line of rev read
             $hash{$currid}{'rev'}{'seq'} = $line;
             $hash{$currid}{'byseq'}{$line} = 'rev';
-        } elsif ($counter % 8 == 7) {
+        } elsif ($modulo == 7) {
             # Qual line of rev read
             $hash{$currid}{'rev'}{'qual'} = $line;
         }

--- a/PhyloFlash.pm
+++ b/PhyloFlash.pm
@@ -1711,9 +1711,9 @@ sub initialize_outfiles_hash {
       "sam_remap_trusted",
       {
         description => "SAM file of read mapping vs trusted contigs",
-        discard     => 1,
+        discard     => 0,
         filename    => "$libraryNAME.trusted.bbmap.sam",
-        intable     => 0,
+        intable     => 1,
       },
       "bbmap_remap_log_trusted",
       {

--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -1098,6 +1098,10 @@ sub parse_mapstats_from_sam_arr {
         # Go through each SAM record and check bitflags to see if mapping or not
         next if $href->{'FLAG'} & 0x100; # Skip secondary alignments
         my ($splitname, @discard) = split /\s/, $href->{'QNAME'}; # Split read name on whitespace and add to hash for counting
+        # Strip read segment suffixes from name 
+        if ($splitname =~ m/^(.+)([:\/_])[12]/) {
+            $splitname = $1.$2;
+        }
         $qname_hash{$splitname} ++;
         if ($href->{'FLAG'} & 0x40) { # Fwd read
             $ssu_f_reads ++ unless $href->{'FLAG'} & 0x4;   # Unless fwd read unmapped

--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -158,7 +158,7 @@ Default: 70
 E-value cutoff to use for SortMeRNA (only if I<-sortmerna> option chosen). In
 scientific exponent notation (see below)
 
-Default: 1e-05
+Default: 1e-09
 
 =item -clusterid I<N>
 
@@ -312,7 +312,7 @@ my $SEmode      = 0;            # single ended mode
 my $libraryNAME = undef;        # output basename
 my $interleaved = 0;            # Flag - interleaved read data in read1 input (default = 0, no)
 my $id          = 70;           # minimum %id for mapping with BBmap
-my $evalue_sortmerna = 1e-05;   # E-value cutoff for sortmerna, ignored if -sortmerna not chosen
+my $evalue_sortmerna = 1e-09;   # E-value cutoff for sortmerna, ignored if -sortmerna not chosen
 my $readlength  = 100;          # length of input reads
 my $readlimit   = -1;           # max # of reads to use
 my $amplimit    = 500000;       # number of SSU pairs at which to switch to emirge_amplicon

--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -148,10 +148,17 @@ Default: 500000
 
 =item -id I<N>
 
-Minimum allowed identity for read mapping process in %. Must be within
+Minimum allowed identity for BBmap read mapping process in %. Must be within
 50..98. Set this to a lower value for very divergent taxa
 
 Default: 70
+
+=item -evalue_sortmerna I<N>
+
+E-value cutoff to use for SortMeRNA (only if I<-sortmerna> option chosen). In
+scientific exponent notation (see below)
+
+Default: 1e-05
 
 =item -clusterid I<N>
 
@@ -304,7 +311,8 @@ my $readsr      = undef;        # reverse read filename, stripped of directory n
 my $SEmode      = 0;            # single ended mode
 my $libraryNAME = undef;        # output basename
 my $interleaved = 0;            # Flag - interleaved read data in read1 input (default = 0, no)
-my $id          = 70;           # minimum %id for mapping
+my $id          = 70;           # minimum %id for mapping with BBmap
+my $evalue_sortmerna = 1e-05;   # E-value cutoff for sortmerna, ignored if -sortmerna not chosen
 my $readlength  = 100;          # length of input reads
 my $readlimit   = -1;           # max # of reads to use
 my $amplimit    = 500000;       # number of SSU pairs at which to switch to emirge_amplicon
@@ -492,6 +500,7 @@ sub parse_cmdline {
                'crlf' => \$crlf,
                'decimalcomma' => \$decimalcomma,
                'sortmerna!' => \$use_sortmerna,
+               'evalue_sortmerna=s' => \$evalue_sortmerna,
                'emirge!' => \$emirge,
                'skip_emirge' => \$skip_emirge,
                'skip_spades' => \$skip_spades,
@@ -1000,7 +1009,7 @@ sub sortmerna_filter_sam {
                           "--log",
                           "--best 10",      # Take 10 best hits
                           "--min_lis 10",
-                          "-e 1.00e-05",    # E-value cutoff
+                          "-e $evalue_sortmerna",    # E-value cutoff
                           "-a $cpus",
                           "-v",             # Verbose (turn off?)
                           );

--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -603,7 +603,7 @@ sub parse_cmdline {
     if ($use_sortmerna == 1) {
         msg ("Sortmerna will be used instead of BBmap for the initial SSU rRNA read extraction");
         msg ("Sortmerna requires uncompressed input files - Ensure that you have enough disk space");
-        msg ("The following input parameters specific to BBMap will be ignored: --id, --tophit, --maxinsert");
+        msg ("The following input parameters specific to BBMap will be ignored: --id, --maxinsert");
     }
 
     # check surplus arguments
@@ -1009,12 +1009,20 @@ sub sortmerna_filter_sam {
                           "--sam",          # SAM alignment output
                           #"--blast 1",     # Blast-tabular alignment output
                           "--log",
-                          "--best 10",      # Take 10 best hits
+                          #"--best 10",      # Take 10 best hits
                           "--min_lis 10",
                           "-e $evalue_sortmerna",    # E-value cutoff
                           "-a $cpus",
                           "-v",             # Verbose (turn off?)
                           );
+    if (defined $tophit_flag) {
+        msg ("Reporting only single best hit per read");
+        push @sortmerna_args, "--best 1";
+    } else {
+        msg ("Reporting 10 best hits per read");
+        push @sortmerna_args, "--best 10";
+    }
+    
     msg ("Running sortmerna:");
     # Run Sortmerna
     run_prog("sortmerna",

--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -2030,7 +2030,13 @@ sub emirge_run {
         } else {
             $ins_used = $ins_me;
         }
-
+        if ($ins_std == 0) {
+            # insert size std dev has to be nonzero or Emirge will refuse to run
+            # SortMeRNA doesn't report insert size, so we make a guess
+            $ins_std = $ins_used / 2;
+            msg ("Warning: No insert size reported by mapper. Using initial guess $ins_std");
+        }
+        
         msg("the insert size used is $ins_used +- $ins_std");
         # FIXME: EMIRGE dies with too many SSU reads, the cutoff needs to be adjusted...
         if ($SSU_total_pairs <= $amplimit) {

--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -2499,7 +2499,7 @@ sub run_plotscript_SVG {
     }
 
     # Piechart of proportion mapped
-    msg("Plotting piechart of mappign ratios");
+    msg("Plotting piechart of mapping ratios");
     my @map_args = ("-pie",
                     $outfiles{"mapratio_csv"}{"filename"},
                     #"-title=\"$SSU_ratio_pc % reads mapped\""

--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -1862,7 +1862,7 @@ sub screen_remappings {
                 } elsif ($pair eq 'rev') {
                     $ssu_rev_map ++ ;
                 }
-                # Check whether has been flagged as mappign to SPAdes or Emirge or trusted contig
+                # Check whether has been flagged as mapping to SPAdes or Emirge or trusted contig
                 if (defined $sam_fixed_href->{$read}{$pair}{"mapped2spades"} | defined $sam_fixed_href->{$read}{$pair}{"mapped2emirge"} | defined $sam_fixed_href->{$read}{$pair}{'mapped2trusted'}) {
                     # Add to total of read segments mapping to a full-length seq
                     $total_assembled ++;
@@ -1870,7 +1870,7 @@ sub screen_remappings {
                     # If not mapping to full-length seq, check if it has mapped to a SILVA ref sequence
                     foreach my $ref (keys %{$sam_fixed_href->{$read}{$pair}}) {
                         if (ref($sam_fixed_href->{$read}{$pair}{$ref}) eq 'HASH' && defined $sam_fixed_href->{$read}{$pair}{$ref}->{'FLAG'}) { # If this is a hashed SAM record
-                            unless ($sam_fixed_href->{$read}{$pair}{$ref}->{'FLAG'} & 0x4) {
+                            unless ($sam_fixed_href->{$read}{$pair}{$ref}->{'FLAG'} & 0x4 || $sam_fixed_href->{$read}{$pair}{$ref}->{'FLAG'} & 0x100) { # Unless segment unmapped or is a secondary alignment
                                 push @unassem_readcounters, $read;
                                 # If using top hit
                                 if ($sam_fixed_href->{$read}{$pair}{$ref}->{'RNAME'} =~ m/\w+\.\d+\.\d+\s(.+)/) {

--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -839,6 +839,8 @@ sub write_csv {
         "NTUs observed twice",$xtons[1],
         "NTUs observed three or more times",$xtons[2],
         "NTU Chao1 richness estimate",sprintf("%.3f",$chao1), # Round to 3 d.p.
+        "program command",$progcmd,
+        "database path",$DBHOME,
     ));
     my $fh;
     open_or_die(\$fh, ">", $outfiles{"report_csv"}{"filename"});

--- a/phyloFlash_compare.pl
+++ b/phyloFlash_compare.pl
@@ -865,7 +865,9 @@ sub calc_weight_tax_unifrac_pair {
     # The equivalent of the scaling factor D would be the total taxonomic rank depth
     # of the tax tree, e.g. 7 for species, 4 for order. The branch length between
     # each rank is implicitly = 1 in the calc_weight_tax_unifrac_pair() procedure
-    return $raw_unifrac / $taxlevel;
+    # The number D in Lozupone et al. 2007 reduces to 2d because d_j is the same
+    # for all j in a taxonomic tree, and sum_j^n (A_j/A_T) is unity.
+    return $raw_unifrac / (2 * $taxlevel);
 }
 
 

--- a/phyloFlash_makedb.pl
+++ b/phyloFlash_makedb.pl
@@ -276,6 +276,7 @@ if (! -e "$dbdir/SILVA_SSU.fasta" || $overwrite == 1 ) {
 my @lsu_in_ssh;
 if (! -e "$dbdir/SILVA_SSU.noLSU.fasta" || $overwrite == 1) {
     @lsu_in_ssh = find_LSU("$dbdir/SILVA_SSU.noLSU.fasta");
+    msg ("Removing sequences with potential LSU contamination");
     fasta_copy_except("$dbdir/SILVA_SSU.fasta",
                       "$dbdir/SILVA_SSU.noLSU.fasta",
                       @lsu_in_ssh,


### PR DESCRIPTION
 * Fix Unifrac-like metric normalization factor 
 * Fix over-counting for taxonomic summary of unassembled reads 
 * Fix bug when read maps to same reference more than once - RNAME field not fixed and warning issued
 * Fix various bugs when fwd and rev read names have suffixes _1 /1 :1 that do not split on whitespace