### PR TITLE
Change wildcard for download path of SILVA database

### DIFF
--- a/PhyloFlash.pm
+++ b/PhyloFlash.pm
@@ -28,7 +28,7 @@ This module contains helper functions shared by the phyloFlash scripts.
 
 =cut
 
-our $VERSION     = "3.3b1";
+our $VERSION     = "3.3b2";
 our @ISA         = qw(Exporter);
 our @EXPORT      = qw(
   $VERSION

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img align="right" src="docs/phyloFlash_logo.png" width="200" alt="phyloFlash logo"/>
 
-# phyloFlash v3.3 beta 1
+# phyloFlash v3.3b2
 
 [![GitHub (pre-)release](https://img.shields.io/github/release/HRGV/phyloflash/all.svg?label=Latest%20Version)]()
 [![Bioconda](https://img.shields.io/conda/vn/Bioconda/phyloFlash.svg)](https://bioconda.github.io/recipes/phyloflash/README.html)
@@ -42,11 +42,11 @@ If you clone the repository directly off GitHub you might end up with a version 
 
 ```bash
 # Download latest release
-wget https://github.com/HRGV/phyloFlash/archive/pf3.3b1.tar.gz
-tar -xzf pf3.3b1.tar.gz
+wget https://github.com/HRGV/phyloFlash/archive/pf3.3b2.tar.gz
+tar -xzf pf3.3b2.tar.gz
 
 # Check for dependencies and install them if necessary
-cd phyloFlash-pf3.3b1
+cd phyloFlash-pf3.3b2
 ./phyloFlash.pl -check_env
 ```
 
@@ -113,6 +113,9 @@ For further information **please refer to the [Manual](https://hrgv.github.io/ph
 
 ## Versions and changes
 
+* v3.3 beta 2
+  * New options to graphical comparison scripts, and other small bug fixes
+  * Fix bug due to change in SILVA project file naming convention with SILVA 138 onwards
 * v3.3 beta 1
   * Add support for using SortMeRNA instead of BBmap for initial mapping step
   * Changes to how mapping data are hashed; process SAM file of initial mapping to fix known bugs with bitflag and read name reporting in BBmap and SortMeRNA

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,11 +46,11 @@ If you clone the repository directly off GitHub you might end up with a version 
 
 ```bash
 # Download latest release
-wget https://github.com/HRGV/phyloFlash/archive/pf3.3b1.tar.gz
-tar -xzf pf3.3b1.tar.gz
+wget https://github.com/HRGV/phyloFlash/archive/pf3.3b2.tar.gz
+tar -xzf pf3.3b2.tar.gz
 
 # Check for dependencies and install them if necessary
-cd phyloFlash-pf3.3b1
+cd phyloFlash-pf3.3b2
 ./phyloFlash.pl -check_env
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,8 +52,8 @@ If you clone the repository directly off GitHub you might end up with a version 
 
 ```bash
 # Download latest release
-wget https://github.com/HRGV/phyloFlash/archive/pf3.3b1.tar.gz
-tar -xzf pf3.3b1.tar.gz
+wget https://github.com/HRGV/phyloFlash/archive/pf3.3b2.tar.gz
+tar -xzf pf3.3b2.tar.gz
 ```
 
 Alternatively clone the latest development version with Git:

--- a/phyloFlash_makedb.pl
+++ b/phyloFlash_makedb.pl
@@ -174,7 +174,7 @@ use Storable;
 use File::Spec;
 
 # URLS
-my $silva_url  = "ftp.arb-silva.de/current/Exports/*_SSURef_Nr99_tax_silva_trunc.fasta.gz";
+my $silva_url  = "ftp.arb-silva.de/current/Exports/*_SSURef_N?99_tax_silva_trunc.fasta.gz";
 my $univec_url = "ftp.ncbi.nlm.nih.gov/pub/UniVec/UniVec";
 
 # constants

--- a/phyloFlash_makedb.pl
+++ b/phyloFlash_makedb.pl
@@ -59,7 +59,8 @@ Path to local copy of SILVA database file. Ignored if --remote flag is used.
 This should be the Fasta-formatted SILVA SSURef file, clustered at 99% identity,
 with SILVA taxonomy strings in file header, and sequences truncated to SSU gene
 boundaries. The file name should be in the form
-I<SILVA_[Release]_SSURef_Nr99_tax_silva_trunc.fasta.gz>
+I<SILVA_[Release]_SSURef_Nr99_tax_silva_trunc.fasta.gz> (release 132 and before) or
+I<SILVA_[Release]_SSURef_NR99_tax_silva_trunc.fasta.gz> (from release 138 onwards)
 
 =item --univec_file F<path/to/univec_db>
 
@@ -172,6 +173,7 @@ use IO::Uncompress::AnyUncompress qw(anyuncompress $AnyUncompressError);
 use Cwd;
 use Storable;
 use File::Spec;
+use File::Basename;
 
 # URLS
 my $silva_url  = "ftp.arb-silva.de/current/Exports/*_SSURef_N?99_tax_silva_trunc.fasta.gz";
@@ -252,7 +254,11 @@ else {
 }
 
 # extract SILVA version
-my ($silva_release) = ($silva_file =~ m/SILVA_([^_]+)_/);
+# get file basename, in case a path is specified
+my ($silva_file_filename, 
+    $silva_file_dirs, 
+    $silva_file_suffix) = fileparse($silva_file);
+my ($silva_release) = ($silva_file_filename =~ m/SILVA_([^_]+)_/);
 
 if (!$&) {
     err("Unable to extract version from SILVA database filename:",


### PR DESCRIPTION
Naming convention changed between releases 132 and 138
This resolves issue #100