### PR TITLE
--phred-offset not recognized

### DIFF
--- a/phyloFlash.pl
+++ b/phyloFlash.pl
@@ -1582,7 +1582,7 @@ sub spades_run {
     my $cpus_spades = $cpus > 24 ? 24 : $cpus;
 
     my $return = run_prog_nodie("spades",
-                                "-o $libraryNAME.spades -t $cpus_spades -m 20 -k $kmer "
+                                "-o $libraryNAME.spades -t $cpus_spades -m 20 -k $kmer --phred-offset 33 "
                                 . $args,
                                 $outfiles{"spades_log"}{"filename"},"&1"
                                 );


### PR DESCRIPTION
Dear phyloflash author,

when fasta file were used for spades.py assembly there was an error about not recognizing phred format. Add this line will solve the problem (most current sequncer like Miseq and Hiseq are all 33 format).

Thanks,

Jianshu 