### PR TITLE
Remove incorrect regex for paired-read name suffix

### DIFF
--- a/PhyloFlash.pm
+++ b/PhyloFlash.pm
@@ -28,7 +28,7 @@ This module contains helper functions shared by the phyloFlash scripts.
 
 =cut
 
-our $VERSION     = "3.4.1";
+our $VERSION     = "3.4.2";
 our @ISA         = qw(Exporter);
 our @EXPORT      = qw(
   $VERSION


### PR DESCRIPTION
Regex does not cover all possible cases, and will incorrectly split names in many cases. Results in read count totals that do not sum up correctly.

Fix for issue #173 