### PR TITLE
Link version of pre-formatted SILVA database with main taxonomic ranks only

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 by Harald Gruber-Vodicka, Elmar A. Pruesse, and Brandon Seah.
 
+***NOTE: This software is only being sporadically maintained. We regret that we
+are unable to respond to issues on a regular basis.***
+
 *phyloFlash* is a pipeline to rapidly reconstruct the SSU rRNAs and explore
 phylogenetic composition of an Illumina (meta)genomic or transcriptomic
 dataset. **[Manual](https://hrgv.github.io/phyloFlash)**
@@ -60,6 +63,7 @@ Pre-formatted databases derived from SILVA releases 138 onwards are available
 from the following Zenodo archives:
 
  * [SILVA 138.1](https://doi.org/10.5281/zenodo.7892521) (latest)
+ * [SILVA 138.1, taxonomy with main ranks only](https://doi.org/10.5281/zenodo.10047346) (see details in repository)
  * [SILVA 138](https://doi.org/10.5281/zenodo.7890453)
 
 Download, checksum, and unpack:

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ Pre-formatted databases derived from SILVA releases 138 onwards are available
 from the following Zenodo archives:
 
  * [SILVA 138.1](https://doi.org/10.5281/zenodo.7892521) (latest)
+ * [SILVA 138.1, taxonomy with main ranks only](https://doi.org/10.5281/zenodo.10047346) (see details in repository)
  * [SILVA 138](https://doi.org/10.5281/zenodo.7890453)
 
 Download, checksum, and unpack:

--- a/docs/install.md
+++ b/docs/install.md
@@ -122,6 +122,7 @@ Pre-formatted databases derived from SILVA releases 138 onwards are available
 from the following Zenodo archives:
 
  * [SILVA 138.1](https://doi.org/10.5281/zenodo.7892521) (latest)
+ * [SILVA 138.1, taxonomy with main ranks only](https://doi.org/10.5281/zenodo.10047346) (see details in repository)
  * [SILVA 138](https://doi.org/10.5281/zenodo.7890453)
 
 NOTE: Prebuilt databases are not provided for SILVA versions before 138,
@@ -157,7 +158,7 @@ phyloFlash_makedb.pl --help
 ```
 
 Download the desired version of the SILVA SSURef NR99 database from [the SILVA
-website](https://www.arb-silva.de/download/archive/) (in Fastsa format) under the `Exports` subfolder of the respective release. The filename should be `SILVA_XXX_SSURef_Nr99_tax_silva_trunc.fasta.gz` where
+website](https://www.arb-silva.de/download/archive/) (in Fasta format) under the `Exports` subfolder of the respective release. The filename should be `SILVA_XXX_SSURef_Nr99_tax_silva_trunc.fasta.gz` where
 `XXX` is the version number. Links to the last five releases:
  * [138.1](https://www.arb-silva.de/fileadmin/silva_databases/release_138.1/Exports/SILVA_138.1_SSURef_NR99_tax_silva_trunc.fasta.gz)
  * [138](https://www.arb-silva.de/fileadmin/silva_databases/release_138/Exports/SILVA_138_SSURef_NR99_tax_silva_trunc.fasta.gz)


### PR DESCRIPTION
New, modified version of SILVA database where only the main taxonomic ranks (domain, kingdom, phylum...) have been retained. DOI link should work in a day or two.

Resolves problem with Eukaryota taxon strings having too many intermediate ranks and being too long vs. Bacteria and Archaea, which made the taxonomic summary less useful for eukaryotes.

This PR updates readme and docs only, code is not affected so there is no need for a new release.